### PR TITLE
feat: add validation to amount field in wallet form

### DIFF
--- a/src/components/AddWallet/AddWallet.jsx
+++ b/src/components/AddWallet/AddWallet.jsx
@@ -72,15 +72,22 @@ export const AddWallet = () => {
               </FormErrorMessage>
             </FormControl>
 
-            <FormControl py="3">
+            <FormControl isInvalid={errors.amount} py="3">
               <FormLabel htmlFor="amount">
                 {i18next.t('addWallet.amount')}
               </FormLabel>
               <Input
-                {...register('amount')}
+                {...register('amount', {
+                  validate: (amount) =>
+                    amount >= 0 ||
+                    i18next.t('addWallet.validationErrorMessage.amount')
+                })}
                 type="number"
                 placeholder={i18next.t('addWallet.amount.placeholder')}
               />
+              <FormErrorMessage>
+                <Text>{errors.amount && errors.amount.message}</Text>
+              </FormErrorMessage>
             </FormControl>
 
             <FormControl isInvalid={errors.currency} isRequired py="3">

--- a/src/i18n/i18n_en.json
+++ b/src/i18n/i18n_en.json
@@ -44,5 +44,6 @@
   "addWallet.validationErrorMessage.tooShort": "Name must be longer than 1 symbols",
   "addWallet.validationErrorMessage.tooLong": "Name must be no longer than 30 symbols",
   "addWallet.validationErrorMessage.default": "Name is not valid",
-  "addWallet.validationErrorMessage.currency": "Please, choose currency"
+  "addWallet.validationErrorMessage.currency": "Please, choose currency",
+  "addWallet.validationErrorMessage.amount": "you can't have negative balance"
 }


### PR DESCRIPTION
### Type of change:

- [x] Feature (introduces new functionality)
- [ ] Bugfix
- [ ] Configuration
- [ ] Refactoring (doesn't change functionality, only the code)
- [ ] Style changes (doesn't affect functionality, only the look of the components)


### PR Checklist:

- [x] Synced up with latest from the main branch/Code is linted
- [x ] Description of the changes has been added (Screenshots/Video)
-
<img width="549" alt="image" src="https://user-images.githubusercontent.com/39521158/180417658-5bd7fd71-ec3e-40f8-8d60-bbbc8f9290c2.png">

- [x] Chakra components/constants/hooks have been used wherever possible
> If not explain here
- [x] Commit messages follow [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
- [x] Console has been checked for warnings

#### Screenshots/Video before change
Add screenshots from the [current deployed state](https://sandbox-money-app.herokuapp.com/) of the changed components here.


#### Screenshots/Video after change
Add screenshots with the changes applied here. 

https://user-images.githubusercontent.com/39521158/180418414-4900fd08-8c97-4c65-9552-31c1e1093087.mov




Note: I didn’t find a default setting for negative numbers so create a custom with a function


