### PR TITLE
fix: focus-visible behaviour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@emotion/styled": "^11.9.3",
         "@hookform/resolvers": "^2.9.6",
         "axios": "^0.27.2",
+        "focus-visible": "^5.2.0",
         "framer-motion": "^6.4.3",
         "i18next": "^21.8.13",
         "react": "^18.0.0",
@@ -5062,6 +5063,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/focus-visible": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
+      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.1",
@@ -12367,6 +12373,11 @@
       "requires": {
         "tslib": "^2.0.3"
       }
+    },
+    "focus-visible": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
+      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
     "follow-redirects": {
       "version": "1.15.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@emotion/styled": "^11.9.3",
     "@hookform/resolvers": "^2.9.6",
     "axios": "^0.27.2",
+    "focus-visible": "^5.2.0",
     "framer-motion": "^6.4.3",
     "i18next": "^21.8.13",
     "react": "^18.0.0",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ChakraProvider } from '@chakra-ui/react';
+import { Global } from '@emotion/react';
 
 import './i18n';
+import 'focus-visible/dist/focus-visible';
 
 import { ErrorBoundary } from './components';
 import { App } from './pages';
-import { theme } from './theme';
+import { GlobalStyles, theme } from './theme';
 
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <ChakraProvider theme={theme}>
+      <Global styles={GlobalStyles} />
       <ErrorBoundary>
         <App />
       </ErrorBoundary>

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,1 +1,1 @@
-export { theme } from './theme';
+export { GlobalStyles, theme } from './theme';

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -1,4 +1,5 @@
 import { extendTheme } from '@chakra-ui/react';
+import { css } from '@emotion/react';
 
 import { Button, Form, Input, Modal, Switch } from './components';
 
@@ -6,6 +7,13 @@ const config = {
   initialColorMode: 'system',
   useSystemColorMode: false
 };
+
+export const GlobalStyles = css`
+  .js-focus-visible :focus:not([data-focus-visible-added]) {
+    outline: none;
+    box-shadow: none;
+  }
+`;
 
 export const theme = extendTheme({
   colors: {


### PR DESCRIPTION
### Description:

The ChakraUI component library overrides the default accessibility outline with it’s own box-shadow property. This behaviour were fixed with help of [focus-visible](https://www.npmjs.com/package/focus-visible) package.
Now box-shadow property applies only when user tabbing through UI, not by clicking the mouse.

<https://github.com/chakra-ui/chakra-ui/issues/2016>
<https://medium.com/@keeganfamouss/accessibility-on-demand-with-chakra-ui-and-focus-visible-19413b1bc6f9>

### Type of change:

- [ ] Feature (introduces new functionality)
- [x] Bugfix
- [x] Configuration
- [ ] Refactoring (doesn't change functionality, only the code)
- [ ] Style changes (doesn't affect functionality, only the look of the components)


### PR Checklist:

- [x] Synced up with latest from the main branch/Code is linted
- [x] Commit messages follow [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
- [x] Console has been checked for warnings