### PR TITLE
feat: create toast message for http error

### DIFF
--- a/src/api/ApiProvider.js
+++ b/src/api/ApiProvider.js
@@ -1,4 +1,8 @@
+import { createStandaloneToast } from '@chakra-ui/toast';
 import axios from 'axios';
+
+export const { ToastContainer, toast } = createStandaloneToast();
+
 export const instance = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
   timeout: 1000
@@ -11,22 +15,52 @@ const responseSuccessInterceptor = (response) => {
 const networkErrorInterceptor = (error) => {
   switch (error.response.status) {
     case 401:
-      console.log('Unauthorized');
+      toast({
+        title: 'Unauthorized',
+        status: 'error',
+        duration: 9000,
+        isClosable: true
+      });
       break;
     case 403:
-      console.log('Forbidden');
+      toast({
+        title: 'Forbidden',
+        status: 'error',
+        duration: 9000,
+        isClosable: true
+      });
       break;
     case 404:
-      console.log('Not Found');
+      toast({
+        title: 'Not Found',
+        status: 'error',
+        duration: 9000,
+        isClosable: true
+      });
       break;
     case 500:
-      console.log('Internal Server Error');
+      toast({
+        title: 'Internal Server Error',
+        status: 'error',
+        duration: 9000,
+        isClosable: true
+      });
       break;
     case 502:
-      console.log('Bad Gateway');
+      toast({
+        title: 'Bad Gateway',
+        status: 'error',
+        duration: 9000,
+        isClosable: true
+      });
       break;
     default:
-      console.log('Error');
+      toast({
+        title: 'Error',
+        status: 'error',
+        duration: 9000,
+        isClosable: true
+      });
       break;
   }
   return Promise.reject(error);

--- a/src/api/ApiProvider.js
+++ b/src/api/ApiProvider.js
@@ -1,13 +1,12 @@
 import { createStandaloneToast } from '@chakra-ui/toast';
 import axios from 'axios';
 
-export const { toast } = createStandaloneToast();
-
 export const instance = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
   timeout: 1000
 });
 
+const { toast } = createStandaloneToast();
 const responseSuccessInterceptor = (response) => {
   return response;
 };

--- a/src/api/ApiProvider.js
+++ b/src/api/ApiProvider.js
@@ -1,7 +1,7 @@
 import { createStandaloneToast } from '@chakra-ui/toast';
 import axios from 'axios';
 
-export const { ToastContainer, toast } = createStandaloneToast();
+export const { toast } = createStandaloneToast();
 
 export const instance = axios.create({
   baseURL: import.meta.env.VITE_API_URL,

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,10 +3,12 @@ import ReactDOM from 'react-dom/client';
 import { ChakraProvider } from '@chakra-ui/react';
 import { Global } from '@emotion/react';
 
+import { ErrorBoundary } from '@/components';
+
 import './i18n';
 import 'focus-visible/dist/focus-visible';
 
-import { ErrorBoundary } from './components';
+import { ToastContainer } from './api/ApiProvider';
 import { App } from './pages';
 import { GlobalStyles, theme } from './theme';
 
@@ -18,6 +20,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
       <Global styles={GlobalStyles} />
       <ErrorBoundary>
         <App />
+        <ToastContainer />
       </ErrorBoundary>
     </ChakraProvider>
   </React.StrictMode>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,7 +8,6 @@ import { ErrorBoundary } from '@/components';
 import './i18n';
 import 'focus-visible/dist/focus-visible';
 
-import { ToastContainer } from './api/ApiProvider';
 import { App } from './pages';
 import { GlobalStyles, theme } from './theme';
 
@@ -20,7 +19,6 @@ ReactDOM.createRoot(document.getElementById('root')).render(
       <Global styles={GlobalStyles} />
       <ErrorBoundary>
         <App />
-        <ToastContainer />
       </ErrorBoundary>
     </ChakraProvider>
   </React.StrictMode>


### PR DESCRIPTION
### Description

create toast messages for cases when  http errors happen

### Type of change

- [x] Feature (introduces new functionality)
- [ ] Bugfix
- [ ] Configuration
- [ ] Refactoring (doesn't change functionality, only the code)
- [ ] Style changes (doesn't affect functionality, only the look of the components)

### PR Checklist

- [x] Synced up with latest from the main branch/Code is linted
- [x] Description of the changes has been added (Screenshots/Video)
- [x] Chakra components/constants/hooks have been used wherever possible

> If not explain here

- [x] Commit messages follow [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
- [x] Console has been checked for warnings (there is an internal server error 500)

#### Screenshots/Video before change
I broke the link with the request to show the error message, I can't do the same in prod. Please, just belive me there wasn't an error message before 

#### Screenshots/Video after change


https://user-images.githubusercontent.com/39521158/182347018-8c3bc471-53c1-43b2-833a-b74c1cceee4c.mov


