### PR TITLE
feat: add Admin user & Admin page

### DIFF
--- a/src/components/Header/NavDrawer.jsx
+++ b/src/components/Header/NavDrawer.jsx
@@ -64,7 +64,13 @@ export const NavDrawer = () => {
             right={10}
             color={textColor}
           />
-          <DrawerHeader pt="30px" minH="100px" pl={6} bg={bgColor}>
+          <DrawerHeader
+            pt="30px"
+            minH="100px"
+            pl={6}
+            bg={bgColor}
+            onClick={onClose}
+          >
             <UserName />
           </DrawerHeader>
           <DrawerBody bg={popupBgColor}>

--- a/src/components/Header/UserName.jsx
+++ b/src/components/Header/UserName.jsx
@@ -24,7 +24,7 @@ export const UserName = () => {
       !!dataUser.data &&
       !!dataUser.data.isAdmin &&
       isFetchedUser ? (
-        <Button as={Link} to="/" fontWeight="bold" size="xs" mr="auto">
+        <Button as={Link} to="/admin" fontWeight="bold" size="xs" mr="auto">
           Admin
         </Button>
       ) : null}

--- a/src/components/Header/UserName.jsx
+++ b/src/components/Header/UserName.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { Button, Flex, Text } from '@chakra-ui/react';
 
 import { getUser } from '@/api/User';
+import { i18n } from '@/i18n';
 import { useCentralTheme } from '@/theme';
 
 export const UserName = () => {
@@ -25,7 +26,7 @@ export const UserName = () => {
       !!dataUser.data.isAdmin &&
       isFetchedUser ? (
         <Button as={Link} to="/admin" fontWeight="bold" size="xs" mr="auto">
-          Admin
+          {i18n.t('admin.button')}
         </Button>
       ) : null}
     </Flex>

--- a/src/components/Header/UserName.jsx
+++ b/src/components/Header/UserName.jsx
@@ -1,5 +1,6 @@
 import { useQuery } from 'react-query';
-import { Flex, Text } from '@chakra-ui/react';
+import { Link } from 'react-router-dom';
+import { Button, Flex, Text } from '@chakra-ui/react';
 
 import { getUser } from '@/api/User';
 import { useCentralTheme } from '@/theme';
@@ -19,6 +20,14 @@ export const UserName = () => {
           {dataUser.data.fullName}
         </Text>
       )}
+      {!!dataUser &&
+      !!dataUser.data &&
+      !!dataUser.data.isAdmin &&
+      isFetchedUser ? (
+        <Button as={Link} to="/" fontWeight="bold" size="xs" mr="auto">
+          Admin
+        </Button>
+      ) : null}
     </Flex>
   );
 };

--- a/src/i18n/i18n_en.json
+++ b/src/i18n/i18n_en.json
@@ -172,5 +172,8 @@
   "transaction.title.amount": "Amount",
   "transaction.title.walletName": "Wallet name",
   "transaction.title.edit": "Edit",
-  "transaction.title.delete": "Delete"
+  "transaction.title.delete": "Delete",
+  "admin.button": "Admin",
+  "admin.welcomePage": "Welcome to Admin page!",
+  "admin.disclaimer": "You can see me only if you have an Admin role ;)"
 }

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -3,6 +3,7 @@ import { Navigate } from 'react-router-dom';
 import { Center, Heading } from '@chakra-ui/react';
 
 import { getUser } from '@/api/User';
+import { Preloader } from '@/components';
 import { i18n } from '@/i18n';
 import { useCentralTheme } from '@/theme';
 
@@ -16,6 +17,7 @@ export const Admin = () => {
 
   return (
     <>
+      {!isFetchedUser ? <Preloader /> : null}
       {!!dataUser &&
       !!dataUser.data &&
       !dataUser.data.isAdmin &&

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,0 +1,35 @@
+import { useQuery } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+import { Center, Heading } from '@chakra-ui/react';
+
+import { getUser } from '@/api/User';
+import { i18n } from '@/i18n';
+
+export const Admin = () => {
+  const { data: dataUser, isFetched: isFetchedUser } = useQuery(
+    ['user'],
+    getUser
+  );
+
+  const navigate = useNavigate();
+
+  return (
+    <>
+      {!!dataUser &&
+      !!dataUser.data &&
+      !!dataUser.data.isAdmin &&
+      isFetchedUser ? (
+        <Center h="full" flexDirection="column">
+          <Heading as="h1" size="xl">
+            {i18n.t('admin.welcomePage')}
+          </Heading>
+          <Heading as="h2" size="md" m={4}>
+            {i18n.t('admin.disclaimer')}
+          </Heading>
+        </Center>
+      ) : (
+        navigate('/', { replace: true })
+      )}
+    </>
+  );
+};

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,9 +1,10 @@
 import { useQuery } from 'react-query';
-import { useNavigate } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import { Center, Heading } from '@chakra-ui/react';
 
 import { getUser } from '@/api/User';
 import { i18n } from '@/i18n';
+import { useCentralTheme } from '@/theme';
 
 export const Admin = () => {
   const { data: dataUser, isFetched: isFetchedUser } = useQuery(
@@ -11,24 +12,24 @@ export const Admin = () => {
     getUser
   );
 
-  const navigate = useNavigate();
+  const { textColor } = useCentralTheme();
 
   return (
     <>
       {!!dataUser &&
       !!dataUser.data &&
-      !!dataUser.data.isAdmin &&
+      !dataUser.data.isAdmin &&
       isFetchedUser ? (
+        <Navigate to="/" replace={true} />
+      ) : (
         <Center h="full" flexDirection="column">
-          <Heading as="h1" size="xl">
+          <Heading as="h1" color={textColor} size="xl">
             {i18n.t('admin.welcomePage')}
           </Heading>
-          <Heading as="h2" size="md" m={4}>
+          <Heading as="h2" color={textColor} size="md" m={4}>
             {i18n.t('admin.disclaimer')}
           </Heading>
         </Center>
-      ) : (
-        navigate('/', { replace: true })
       )}
     </>
   );

--- a/src/pages/App.jsx
+++ b/src/pages/App.jsx
@@ -5,6 +5,7 @@ import { AppLayout } from '@/components/Layout';
 import { PrivateRoute } from '@/components/Routes/PrivateRoute';
 import { PublicRoute } from '@/components/Routes/PublicRoute';
 
+import { Admin } from './Admin';
 import { Categories } from './Categories';
 import { Expenses } from './Expenses';
 import { Fallback } from './Fallback';
@@ -38,6 +39,7 @@ export const App = () => {
             }
           >
             <Route path="/" element={<Landing />} />
+            <Route path="/admin" element={<Admin />} />
             <Route path="/incomes" element={<Incomes />} />
             <Route path="/categories" element={<Categories />} />
 


### PR DESCRIPTION
### Description

- render "Admin" button if user have that role
- add "/admin" page
- user without admin role don't have an access to "/admin" page

"Admin" button were added under the username. In that way it looks better than other positioning variants and our layout don't break out.

### Type of change

- [x] Feature (introduces new functionality)
- [ ] Bugfix
- [ ] Configuration
- [ ] Refactoring (doesn't change functionality, only the code)
- [x] Style changes (doesn't affect functionality, only the look of the components)

### PR Checklist

- [x] Synced up with latest from the main branch/Code is linted
- [x] Description of the changes has been added (Video)
- [x] Chakra components/constants/hooks have been used wherever possible
- [x] Commit messages follow [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
- [x] Console has been checked for warnings

#### Video after change

https://user-images.githubusercontent.com/68731150/184403000-03a0b2dc-84d0-48d4-a78d-aa614e1f14bd.mov

https://user-images.githubusercontent.com/68731150/184403993-843d7c0a-2b39-4dde-8640-9b3a57d46b1e.mov

https://user-images.githubusercontent.com/68731150/184403112-36d079f8-4d56-4f11-847c-16e6ca903ade.mov
